### PR TITLE
Implement a basic recursive get_fallback_message method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [0.1.1] - 2019-09-05
+
+- Fix fallback message of [nested exceptions](https://github.com/Hipo/hipo-drf-exceptions/issues/4).
+
+[0.1.0]: https://pypi.org/project/hipo-drf-exceptions/0.1.1/
+
+
 ## [0.1.0] - 2019-07-03
 
 Initial release

--- a/hipo_drf_exceptions/handlers.py
+++ b/hipo_drf_exceptions/handlers.py
@@ -8,29 +8,35 @@ from rest_framework.settings import api_settings
 from rest_framework.views import exception_handler
 
 
-def handler(exc, context):
-    def get_automated_fallback_message(name_of_field, error_message):
-        return "'{field_name}' has an error. {error_message}".format(
-            field_name=name_of_field.capitalize(),
-            error_message=error_message,
-        )
+def get_fallback_message(exception):
+    if isinstance(exception, str):
+        return exception.capitalize()
+    elif isinstance(exception, list):
+        return get_fallback_message(exception[0])
+    elif isinstance(exception, dict):
+        first_key = next(iter(exception))
+        return get_fallback_message(exception[first_key])
+    elif isinstance(exception, Exception):
+        if hasattr(exception, "detail"):
+            return get_fallback_message(exception.detail)
 
+    return exception.__str__()
+
+
+def handler(exc, context):
     # It's a django validation error?
     if isinstance(exc, ValidationError):
         try:
             detail = exc.message_dict
-            field_name = next(iter(detail))
-            fallback_message = get_automated_fallback_message(field_name, detail[field_name][0])
         except AttributeError:
             detail = {
                 api_settings.NON_FIELD_ERRORS_KEY: exc.messages
             }
-            fallback_message = exc.messages[0]
 
         data = {
             'type': exc.__class__.__name__,
             'detail': detail,
-            'fallback_message': fallback_message
+            'fallback_message': get_fallback_message(exc)
         }
         response = Response(data, status=status.HTTP_400_BAD_REQUEST)
     else:  # API Exception.
@@ -39,14 +45,8 @@ def handler(exc, context):
         if response is not None:
             if isinstance(exc, Http404):
                 detail = _("Not Found.")
-                fallback_message = detail
             else:
                 detail = exc.detail
-                try:
-                    field_name = next(iter(detail))
-                    fallback_message = get_automated_fallback_message(field_name, detail[field_name][0])
-                except TypeError:
-                    fallback_message = detail.capitalize()
 
             if not isinstance(detail, dict):
                 # It must be list of errors.
@@ -60,7 +60,7 @@ def handler(exc, context):
             response.data = {
                 'type': exc.__class__.__name__,
                 'detail': detail,
-                'fallback_message': fallback_message
+                'fallback_message': get_fallback_message(exc)
             }
 
     return response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hipo-drf-exceptions"
-version = "0.1.0"
+version = "0.1.1"
 description = "A Django app for returning consistent, verbose and easy to parse error messages on Django Rest Framework backends."
 authors = ["Hipo <pypi@hipolabs.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Fixes [this](https://github.com/Hipo/hipo-drf-exceptions/issues/4).

The behaviour of a fallback message will change with this PR.

**Before:**
```json
{
    "type": "ValidationError",
    "detail": {
        "password": [
            "This field is required."
        ]
    },
    "fallback_message": "'password' has an error. This field is required."
}
```

**After:**
```json
{
    "type": "ValidationError",
    "detail": {
        "password": [
            "This field is required."
        ]
    },
    "fallback_message": "This field is required."
}
```