### PR TITLE
Update get_fallback_message for Django ValidationError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.1.3] - 2019-12-05
+
+- Fix fallback_message of Django [ValidationError](https://github.com/Hipo/hipo-drf-exceptions/issues/10).
+
+[0.1.3]: https://pypi.org/project/hipo-drf-exceptions/0.1.3/
+
 ## [0.1.2] - 2019-10-17
 
 - Fix [bulk exceptions](https://github.com/Hipo/hipo-drf-exceptions/issues/9).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [0.1.3] - 2019-12-05
+## [0.1.3] - 2019-12-09
 
 - Fix fallback_message of Django [ValidationError](https://github.com/Hipo/hipo-drf-exceptions/issues/10).
 

--- a/hipo_drf_exceptions/__init__.py
+++ b/hipo_drf_exceptions/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 
 from hipo_drf_exceptions.handlers import handler
 from hipo_drf_exceptions.exceptions import BaseAPIException

--- a/hipo_drf_exceptions/handlers.py
+++ b/hipo_drf_exceptions/handlers.py
@@ -22,6 +22,9 @@ def get_fallback_message(exception):
     elif isinstance(exception, Exception):
         if hasattr(exception, "detail"):
             return get_fallback_message(exception.detail)
+        elif hasattr(exception, "message"):
+            # Handle Django ValidationError message attribute
+            return get_fallback_message(exception.message)
 
     return exception.__str__()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hipo-drf-exceptions"
-version = "0.1.2"
+version = "0.1.3"
 description = "A Django app for returning consistent, verbose and easy to parse error messages on Django Rest Framework backends."
 authors = ["Hipo <pypi@hipolabs.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Fixes https://github.com/Hipo/hipo-drf-exceptions/issues/10 by handling `message` attribute of Django ValidationError.